### PR TITLE
Fix socket reset errors when counting

### DIFF
--- a/lib/pages/collections.dart
+++ b/lib/pages/collections.dart
@@ -42,9 +42,12 @@ class CollectionsState extends State<Collections> {
   }
 
   Future<void> getRecordCounts() async {
-    Iterable<Future<int>> futures =
-        collections.map((q) => MongoService().getRecordCount(q.item.name));
-    List<int> counts = await Future.wait(futures);
+    List<int> counts = [];
+    for (int i = 0; i < collections.length; i++) {
+      String name = collections[i].item.name;
+      int c = await MongoService().getRecordCount(name);
+      counts.add(c);
+    }
     setState(() {
       for (int i = 0; i < counts.length; i++) {
         collections[i].item.count = counts[i];


### PR DESCRIPTION
When trying to count the number of documents in several collections at once, an error is thrown for all the collections:

```
MongoService.getRecordCount: error for collection=xxx -> MongoDB ConnectionException: connection closed: The socket connection has been reset by peer.
I/flutter (22421): Possible causes:
I/flutter (22421): - Trying to connect to an ssl/tls encrypted database without specifiyng
I/flutter (22421): either the query parm tls=true or the secure=true parameter in db.open()
I/flutter (22421): - The server requires a key certificate from the client, but no certificate has been sent
I/flutter (22421): - Others
```

But it's actually none of those possible causes - perhaps this is only some DOS protection of mongodb.com and is not present on self-hosted databases, either way, the count requests being sent sequentially eliminates this issue 👍